### PR TITLE
For security, we don't want to include the checkmark in plaintext

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -19,12 +19,12 @@
       // This only gets executed once per website use so the nonce can't be reused
       var nonce = "000000000000000000000000";
 
-      console.log("loading");
+      console.log("Decrypting secure checkmark");
       nacl_factory.instantiate(function (nacl) {
           var ciphertext = document.getElementById("checkmark").value;
-          var plaintext = nacl.crypto_secretbox_open(nacl.from_hex(ciphertext), nonce, nacl.encode_utf8(key));
-          document.getElementById("encrypted").insertAdjacentHTML("beforeend", nacl.decode_utf8(plaintext));
-          console.log(plaintext);
+          var plaintext = nacl.decode_utf8(nacl.crypto_secretbox_open(nacl.from_hex(ciphertext), nonce, nacl.encode_utf8(key)));
+          document.getElementById("encrypted").insertAdjacentHTML("beforeend", plaintext);
+          console.log("Decrypted: " + plaintext);
       });
       }
     </script>

--- a/site/index.html
+++ b/site/index.html
@@ -21,9 +21,10 @@
 
       console.log("Decrypting secure checkmark");
       nacl_factory.instantiate(function (nacl) {
-          var ciphertext = document.getElementById("checkmark").value;
+          var _tmp = document.getElementById("encrypted");
+          var ciphertext = _tmp.dataset.ciphertext;
           var plaintext = nacl.decode_utf8(nacl.crypto_secretbox_open(nacl.from_hex(ciphertext), nonce, nacl.encode_utf8(key)));
-          document.getElementById("encrypted").insertAdjacentHTML("beforeend", plaintext);
+          _tmp.insertAdjacentHTML("beforeend", plaintext);
           console.log("Decrypted: " + plaintext);
       });
       }
@@ -31,8 +32,7 @@
   </head>
   <body onload="main()">
     <img src="img/lnc-certified.png"><br>
-    <input type="hidden" value="a059b2c6c69a51986b8e7e8bacced5ae80b74f2a777dc469812dfec687f3339917c79553155b32c26b5b061c031556f7" id="checkmark"></input>
-    <div id="encrypted"></div>
+    <div id="encrypted" data-ciphertext="a059b2c6c69a51986b8e7e8bacced5ae80b74f2a777dc469812dfec687f3339917c79553155b32c26b5b061c031556f7"></div>
     <img src="img/HACKERSAFE.jpeg"><br>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -10,10 +10,29 @@
         agent.speak("It looks like you're using an insecure browser. Have you considered Internet Explorer?");
       });
     </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-nacl/1.2.2/nacl_factory.min.js"></script>
+    <script>
+      function main() {
+      // I generated these on my Macbook which has a TPM, so they are unreadable by government agencies
+      var key = "66daafde4e67050c60e3923a5ecef175";
+
+      // This only gets executed once per website use so the nonce can't be reused
+      var nonce = "000000000000000000000000";
+
+      console.log("loading");
+      nacl_factory.instantiate(function (nacl) {
+          var ciphertext = document.getElementById("checkmark").value;
+          var plaintext = nacl.crypto_secretbox_open(nacl.from_hex(ciphertext), nonce, nacl.encode_utf8(key));
+          document.getElementById("encrypted").insertAdjacentHTML("beforeend", nacl.decode_utf8(plaintext));
+          console.log(plaintext);
+      });
+      }
+    </script>
   </head>
-  <body>
-    <img src="img/norton.png"><br>
+  <body onload="main()">
     <img src="img/lnc-certified.png"><br>
+    <input type="hidden" value="a059b2c6c69a51986b8e7e8bacced5ae80b74f2a777dc469812dfec687f3339917c79553155b32c26b5b061c031556f7" id="checkmark"></input>
+    <div id="encrypted"></div>
     <img src="img/HACKERSAFE.jpeg"><br>
   </body>
 </html>


### PR DESCRIPTION
since then the goverment might be able to read it. Encrypt it instead using js_nacl.

nacl is secure because it was written by djb.